### PR TITLE
TaskGroup.create_task: support `name` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ The implementation has been borrowed from the EdgeDB project.
 ### 23.1.1 (UNRELEASED)
 
 - Add Trove classifiers.
+- Add `name` keyword-only parameter to `TaskGroup.create_task`.
+  ([#8](https://github.com/Tinche/quattro/pull/8))
 
 ### 23.1.0 (2023-11-29)
 

--- a/src/quattro/taskgroup.py
+++ b/src/quattro/taskgroup.py
@@ -169,7 +169,11 @@ except ImportError:
                 raise me from None
 
         def create_task(
-            self, coro: Coroutine[Any, Any, R], *, context: Optional[Context] = None
+            self,
+            coro: Coroutine[Any, Any, R],
+            *,
+            name: Optional[str] = None,
+            context: Optional[Context] = None,
         ) -> "Task[R]":
             if self._exiting:
                 raise RuntimeError(f"TaskGroup {self!r} is awaiting in exit")
@@ -177,9 +181,9 @@ except ImportError:
                 raise RuntimeError(f"TaskGroup {self!r} has not been entered")
             assert self._parent_task
             if context is None:
-                task = self._loop.create_task(coro)
+                task = self._loop.create_task(coro, name=name)
             else:
-                task = context.run(self._loop.create_task, coro)
+                task = context.run(self._loop.create_task, coro, name=name)
             task.add_done_callback(
                 partial(
                     self._on_task_done, loop=self._loop, parent_task=self._parent_task

--- a/tests/test_taskgroup.py
+++ b/tests/test_taskgroup.py
@@ -650,6 +650,31 @@ async def test_taskgroup_23():
         assert not len(g._tasks)
 
 
+async def test_taskgroup_24():
+    """TaskGroup.create_task 'name' argument attaches name to returned task."""
+
+    task_name = "foo"
+
+    async with taskgroup.TaskGroup() as g:
+        task = g.create_task(asyncio.sleep(0), name=task_name)
+
+    assert task.get_name() == task_name
+
+
+async def test_taskgroup_25():
+    """TaskGroup.create_task 'name' argument attaches name to returned task
+    when given an explicit context.
+    """
+
+    task_name = "foo"
+    context = copy_context()
+
+    async with taskgroup.TaskGroup() as g:
+        task = g.create_task(asyncio.sleep(0), name=task_name, context=context)
+
+    assert task.get_name() == task_name
+
+
 async def test_misc():
     """Test misc edge cases, for coverage."""
 


### PR DESCRIPTION
Brings the `TaskGroup.create_task` API in line with `asyncio.TaskGroup.create_task`. The `name` parameter allows you to name the task at creation, instead of having to manually call `Task.set_name` later on.

Thanks for your consideration!